### PR TITLE
Adds an include for <sys/wait.h> thereby removing a compiler warning

### DIFF
--- a/proc.h
+++ b/proc.h
@@ -410,7 +410,6 @@ static int
 tino_wait_child_exact(pid_t child, char **cause)
 {
   int	status;
-  int   ret;
 
   /* This can only return 0
    */

--- a/proc.h
+++ b/proc.h
@@ -238,7 +238,7 @@ static pid_t
 tino_fork_execO(int *fds, int cnt, char * const *argv, char * const *env, int addenv, int *keepfd)
 {
   pid_t	chld;
-  
+
   chld = tino_fork_execE(fds, cnt, argv, env, addenv, keepfd);
   if (chld==(pid_t)-1)
     tino_exit("fork");
@@ -410,11 +410,14 @@ static int
 tino_wait_child_exact(pid_t child, char **cause)
 {
   int	status;
+  int   ret;
 
   /* This can only return 0
    */
   tino_wait_child(child, -1l, &status);
-  return tino_wait_child_status(status, cause);
+  ret = tino_wait_child_status(status, cause);
+  free(*cause);
+  return ret;
 }
 
 /* Poll for any child

--- a/proc.h
+++ b/proc.h
@@ -415,9 +415,7 @@ tino_wait_child_exact(pid_t child, char **cause)
   /* This can only return 0
    */
   tino_wait_child(child, -1l, &status);
-  ret = tino_wait_child_status(status, cause);
-  free(*cause);
-  return ret;
+  return tino_wait_child_status(status, cause);
 }
 
 /* Poll for any child

--- a/signals.h
+++ b/signals.h
@@ -1,5 +1,5 @@
 /* Signal handling
- * 
+ *
  * This is release early code.  Use at own risk.
  *
  * This Works is placed under the terms of the Copyright Less License,
@@ -10,6 +10,7 @@
 #define tino_INC_signals_h
 
 #include <signal.h>
+#include <sys/wait.h>
 #include "sysfix.h"
 #include "fatal.h"
 


### PR DESCRIPTION
`signals.h` uses `waitpid` in a while loop on line 234 offset 10, however since we haven't included `<sys/wait.h>` the compiler warns about using a function with an implicit declaration.

Sorry about the trailing white space that got removed, hope that isn't a problem.
